### PR TITLE
Restore `state.on` turning `false` immediately after turning off the TV with `turnOff`

### DIFF
--- a/main.js
+++ b/main.js
@@ -46,8 +46,20 @@ function startAdapter(options) {
                                 if (!err) adapter.setState('states.turnOff', state.val, true);
                             });
                         } else {
-                            sendCommand('ssap://system/turnOff', { message: state.val }, (err, _) => {
-                                if (!err) adapter.setState('states.turnOff', state.val, true);
+                            adapter.getState(adapter.namespace + '.states.on', (err, tv_on) => {
+                                if (err) { adapter.log.debug('Error getting "on" state ' + err); return; }
+                                if (!tv_on.val) {
+                                    adapter.log.debug('TV is already off');
+                                    adapter.setState('states.turnOff', state.val, true);
+                                    return;
+                                }
+
+                                sendCommand('ssap://system/turnOff', (err, val) => {
+                                    if (!err && val.returnValue === true) {
+                                        adapter.setState('states.turnOff', state.val, true);
+                                        adapter.setState('states.on', false, true);
+                                    }
+                                });
                             });
                         }
                         break;
@@ -60,8 +72,20 @@ function startAdapter(options) {
                                     if (!err) adapter.setState('states.power', state.val, true);
                                 });
                             } else {
-                                sendCommand('ssap://system/turnOff', { message: state.val }, (err, _val) => {
-                                    if (!err) adapter.setState('states.power', state.val, true);
+                                adapter.getState(adapter.namespace + '.states.on', (err, tv_on) => {
+                                    if (err) { adapter.log.debug('Error getting "on" state ' + err); return; }
+                                    if (!tv_on.val) {
+                                        adapter.log.debug('TV is already off');
+                                        adapter.setState('states.power', state.val, true);
+                                        return;
+                                    }
+
+                                    sendCommand('ssap://system/turnOff', (err, val) => {
+                                        if (!err && val.returnValue === true) {
+                                            adapter.setState('states.power', state.val, true);
+                                            adapter.setState('states.on', false, true);
+                                        }
+                                    });
                                 });
                             }
                         } else {


### PR DESCRIPTION
Restore the functionality reported in #80 and originally fixed by #82.

This reverts commit 4c4d4fd864a465293fd12ef224847510e702449b.

#165