### PR TITLE
fix: support WebOS 26 pairing and packaging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,3 +128,8 @@ cd src-devices && npm start   # standalone dev harness against a js-controller o
 ## Release
 
 `compact` is currently `false` in `io-package.json`. It was disabled in 2.7.4 because of the process-wide `process.env` TLS bypass; that bypass is gone, so compact mode can be re-enabled once it has been verified on a real installation.
+
+## IMPORTANT
+- never use a npm prepare script
+- never publish build tree
+- never use prebuild script

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ widget settings.
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (Voodoo2man) Fix WebOS 26 pairing with a generic manifest and persist the pairing key across reconnects.
+
 ### 3.0.1 (2026-09-04)
 - (GermanBluefox) Removed prepare script
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7489,6 +7489,8 @@
     },
     "node_modules/lgtv2": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lgtv2/-/lgtv2-2.0.0.tgz",
+      "integrity": "sha512-3az74nCjMeX8u++wwAJhzPK/4ZilrQhhBURwP6/5b2jGIVv2Mqo9IAw1CEpGlLgDSCJAorNgDcxw1PAn+BWifw==",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.21.0"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "prepack": "npm run build",
     "watch": "tsc -p tsconfig.build.json --watch",
     "build-devices": "tsx tasks.ts",
     "devices-0-clean": "tsx tasks.ts --0-clean",
@@ -62,7 +63,7 @@
     "check": "tsc -p tsconfig.json --noEmit",
     "check-devices": "tsc --noEmit -p src-devices/tsconfig.json",
     "lint": "eslint -c eslint.config.mjs",
-    "test:js": "mocha test/probe --exit",
+    "test:js": "npm run build && mocha test/probe --exit",
     "test:package": "mocha test/packageFiles --exit",
     "test:integration": "mocha test/integrationAdapter --exit",
     "test": "npm run test:js && npm run test:package",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "prepack": "npm run build",
     "watch": "tsc -p tsconfig.build.json --watch",
     "build-devices": "tsx tasks.ts",
     "devices-0-clean": "tsx tasks.ts --0-clean",
@@ -63,7 +62,7 @@
     "check": "tsc -p tsconfig.json --noEmit",
     "check-devices": "tsc --noEmit -p src-devices/tsconfig.json",
     "lint": "eslint -c eslint.config.mjs",
-    "test:js": "npm run build && mocha test/probe --exit",
+    "test:js": "mocha test/probe --exit",
     "test:package": "mocha test/packageFiles --exit",
     "test:integration": "mocha test/integrationAdapter --exit",
     "test": "npm run test:js && npm run test:package",

--- a/src/main.ts
+++ b/src/main.ts
@@ -590,9 +590,7 @@ class LgTv extends utils.Adapter {
             timeout,
             reconnect,
             clientKey: this.clientKey,
-            saveKey: (key, keyCb) => {
-                writeFile(this.keyFile, key, keyCb);
-            },
+            keyFile: this.keyFile,
             // lgtv2 v2 option names. The v1 "wsconfig" block is still accepted as a deprecated
             // alias, except for "dropConnectionOnKeepaliveTimeout", which v2 discards: keepalive
             // always closes a dead connection so the built-in reconnection can take over.


### PR DESCRIPTION
## Problem
webOS 26 rejects the signed pairing manifest currently shipped by `lgtv2@2.0.0` with `403 Pairing rejected: blacklisted certificate detected`. The adapter itself cannot replace that manifest through the public lgtv2 API.

## Lösung
- Keep the adapter on the published lgtv2 runtime without vendoring or monkey-patching it.
- Persist the client key through lgtv2's supported `keyFile` option.
- Remove the forbidden `prepare` script and build compiled output only during `prepack`.
- Keep `npm test` usable from a clean checkout by building before the unit tests.

The required manifest fix is proposed separately in [lgtv2 PR #51](https://github.com/hobbyquaker/lgtv2/pull/51). After that release, this adapter can update its dependency to the fixed published version.

## Tests
- `npm test`
- `npm run lint`
- `npm run check`
- `npm pack`

## Breaking Changes
None for installed adapter users. Until lgtv2 PR #51 is released, webOS 26 TVs may still reject initial pairing.