### PR TITLE
fix: use lgtv2 2.0.1 for WebOS 26 pairing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^3.4.3",
-        "lgtv2": "^2.0.0",
+        "lgtv2": "^2.0.1",
         "wol": "^1.0.7"
       },
       "devDependencies": {
@@ -7488,7 +7488,9 @@
       }
     },
     "node_modules/lgtv2": {
-      "version": "2.0.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lgtv2/-/lgtv2-2.0.1.tgz",
+      "integrity": "sha512-CfOYzaAox/qU0gqUafxfpZAvr3Kl/mJFp2/d1aLqtMsnxfGHgT/vwFSc5pfxd85lh3sAaJiX2W5u6+WWZVz1Jw==",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.21.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.4.3",
-    "lgtv2": "^2.0.0",
+    "lgtv2": "^2.0.1",
     "wol": "^1.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

WebOS 26 TVs can reject the signed pairing manifest shipped by lgtv2 2.0.0 with `403 Pairing rejected: blacklisted certificate detected`.

## Change

Update the adapter dependency from `lgtv2 ^2.0.0` to the released `lgtv2 ^2.0.1`, which retries registration with an unsigned manifest only for that WebOS 26 error while preserving the signed-manifest path for older TVs.

## Validation

- `npm run build`
- `npm run check`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`

The updated package was also installed and tested on ioBroker with both a WebOS 26 TV and a WebOS 24/25 TV.