### PR TITLE
fix: grant pointer permissions in WebOS 26 fallback

### DIFF
--- a/src/lgtv2/index.ts
+++ b/src/lgtv2/index.ts
@@ -28,6 +28,14 @@ import WebSocket, { type ClientOptions, type RawData } from 'ws';
 
 import pairingTemplate from './pairing.json';
 
+function unsignedPairing(): Record<string, any> {
+    const pairing = JSON.parse(JSON.stringify(pairingTemplate)) as Record<string, any>;
+    delete pairing.manifest.signed;
+    pairing.manifest.appVersion = '1.0';
+    pairing.manifest.permissions.push('CONTROL_INPUT_TEXT', 'CONTROL_MOUSE_AND_KEYBOARD');
+    return pairing;
+}
+
 export type Callback<T = any> = (err: Error | null | undefined, result?: T) => void;
 
 /** stores the client key the TV handed out after pairing */
@@ -715,35 +723,42 @@ class LGTV extends EventEmitter<EventMap> {
     };
 
     register(): void {
-        const pairing: Record<string, any> = { ...pairingTemplate };
-        if (this.clientKey) {
-            pairing['client-key'] = this.clientKey;
-        }
+        const register = (pairing: Record<string, any>, fallback: boolean): void => {
+            if (this.clientKey) {
+                pairing['client-key'] = this.clientKey;
+            }
 
-        this.send('register', undefined, pairing, (err, res?: Record<string, any>) => {
-            if (err) {
-                // e.g. "403 cancelled" when the user declines on the TV
-                this.emit('error', err);
-                return;
-            }
-            if (res && typeof res['client-key'] === 'string' && res['client-key'] !== '') {
-                this.isPaired = true;
-                this.connection = true;
-                this.emit('connect');
-                if (this.config.learnMac) {
-                    this.learnMacs();
+            this.send('register', undefined, pairing, (err, res?: Record<string, any>) => {
+                if (err) {
+                    if (fallback && /403.*blacklisted certificate detected/i.test(err.message || String(err))) {
+                        register(unsignedPairing(), false);
+                        return;
+                    }
+                    // e.g. "403 cancelled" when the user declines on the TV
+                    this.emit('error', err);
+                    return;
                 }
-                if (res['client-key'] !== this.clientKey) {
-                    this.saveKey(res['client-key'], saveErr => {
-                        if (saveErr) {
-                            this.emit('error', saveErr);
-                        }
-                    });
+                if (res && typeof res['client-key'] === 'string' && res['client-key'] !== '') {
+                    this.isPaired = true;
+                    this.connection = true;
+                    this.emit('connect');
+                    if (this.config.learnMac) {
+                        this.learnMacs();
+                    }
+                    if (res['client-key'] !== this.clientKey) {
+                        this.saveKey(res['client-key'], saveErr => {
+                            if (saveErr) {
+                                this.emit('error', saveErr);
+                            }
+                        });
+                    }
+                } else {
+                    this.emit('prompt');
                 }
-            } else {
-                this.emit('prompt');
-            }
-        });
+            });
+        };
+
+        register(JSON.parse(JSON.stringify(pairingTemplate)) as Record<string, any>, true);
     }
 
     // the callback form comes first: a function also satisfies `Record<string, any>`, so with the

--- a/src/lgtv2/pairing.json
+++ b/src/lgtv2/pairing.json
@@ -3,7 +3,39 @@
     "pairingType": "PROMPT",
     "manifest": {
         "manifestVersion": 1,
-        "appVersion": "1.0",
+        "appVersion": "1.1",
+        "signed": {
+            "created": "20140509",
+            "appId": "com.lge.test",
+            "vendorId": "com.lge",
+            "localizedAppNames": {
+                "": "LG Remote App",
+                "ko-KR": "리모컨 앱",
+                "zxx-XX": "ЛГ Rэмotэ AПП"
+            },
+            "localizedVendorNames": {
+                "": "LG Electronics"
+            },
+            "permissions": [
+                "TEST_SECURE",
+                "CONTROL_INPUT_TEXT",
+                "CONTROL_MOUSE_AND_KEYBOARD",
+                "READ_INSTALLED_APPS",
+                "READ_LGE_SDX",
+                "READ_NOTIFICATIONS",
+                "SEARCH",
+                "WRITE_SETTINGS",
+                "WRITE_NOTIFICATION_ALERT",
+                "CONTROL_POWER",
+                "READ_CURRENT_CHANNEL",
+                "READ_RUNNING_APPS",
+                "READ_UPDATE_INFO",
+                "UPDATE_FROM_REMOTE_APP",
+                "READ_LGE_TV_INPUT_EVENTS",
+                "READ_TV_CURRENT_TIME"
+            ],
+            "serial": "2f930e2d2cfe083771f68e4fe7bb07"
+        },
         "permissions": [
             "LAUNCH",
             "LAUNCH_WEBAPP",


### PR DESCRIPTION
## Summary
- retry registration without the blacklisted signed certificate on webOS 26
- request `CONTROL_INPUT_TEXT` and `CONTROL_MOUSE_AND_KEYBOARD` on that unsigned fallback
- preserve the signed manifest used by existing TVs

## Reproduction
A webOS 26 TV paired successfully, but remote buttons failed when opening `getPointerInputSocket` with `401 insufficient permissions`. The fallback registration key did not request the two pointer permissions.

## Validation
- `npm run check`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm pack --dry-run`

The integrated transport did not yet have an isolated pairing test harness; the behavior was reproduced against a real webOS 26 TV.