### PR TITLE
fix: do not start the connection check while the adapter is unloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ Install this adapter using ioBroker repositories.
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (krobipd) Stopping the adapter while the TV was connected no longer logs "setTimeout called, but adapter is shutting down"
+
 ### 3.0.3 (2026-09-05)
 - (GermanBluefox) The WebOS 26 pairing fallback now also asks for the pointer permissions, so the remote buttons, pointer moves, scrolling and clicks work after a fresh pairing
 - (GermanBluefox) Older TVs get the signed pairing manifest again; the unsigned manifest is only used after the TV rejected the signed one (ported from lgtv2 2.0.1)

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Install this adapter using ioBroker repositories.
 -->
 ### **WORK IN PROGRESS**
 - (krobipd) Stopping the adapter while the TV was connected no longer logs "setTimeout called, but adapter is shutting down"
+- (krobipd) A stopped or crashed instance no longer keeps reporting `info.connection` as connected
 
 ### 3.0.3 (2026-09-05)
 - (GermanBluefox) The WebOS 26 pairing fallback now also asks for the pointer permissions, so the remote buttons, pointer moves, scrolling and clicks work after a fresh pairing

--- a/src/main.ts
+++ b/src/main.ts
@@ -174,6 +174,8 @@ class LgTv extends utils.Adapter {
     private lastConnectingAt = 0;
     private watchdogTimer: ioBroker.Interval | undefined = undefined;
     private watchdogProbeInFlight = false;
+    /** set in onUnload: the `close` event of the final disconnect must not start a new timer */
+    private unloading = false;
 
     public constructor(options: Partial<utils.AdapterOptions> = {}) {
         super({ ...options, systemConfig: true, name: 'lgtv' });
@@ -880,6 +882,11 @@ class LgTv extends utils.Adapter {
     }
 
     private checkConnection(secondCheck?: boolean): void {
+        if (this.unloading) {
+            // disconnect() in onUnload emits `close` after the unload callback has run;
+            // a timer started now would only produce "setTimeout called, but adapter is shutting down"
+            return;
+        }
         if (secondCheck) {
             if (!this.isConnect) {
                 void this.setStateChanged('info.connection', false, true);
@@ -1124,6 +1131,7 @@ class LgTv extends utils.Adapter {
     }
 
     private onUnload(callback: () => void): void {
+        this.unloading = true;
         try {
             this.clearTimeout(this.renewTimeout);
             if (this.healthInterval) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1093,6 +1093,11 @@ class LgTv extends utils.Adapter {
     }
 
     private onReady(): void {
+        // Nothing is connected yet, and a previous run that was killed rather than unloaded left
+        // its own `true` behind - the host does not reset it (its reset reads
+        // <ns>.info.connection but writes to the namespace root). Start from the truth.
+        void this.setStateChanged('info.connection', false, true);
+
         if (!this.config.ip) {
             this.log.error('No configure IP address');
             return;
@@ -1146,7 +1151,16 @@ class LgTv extends utils.Adapter {
         } catch {
             // ignore errors during shutdown
         }
-        callback();
+        // Reset info.connection here: the path that would do it (checkConnection, 10 s after the
+        // close event) is exactly the one suppressed above, and the host does not do it either -
+        // its own reset reads <ns>.info.connection but writes to the namespace root. Without this
+        // a stopped instance keeps reporting "connected". The callback must follow the write, not
+        // race it: a fire-and-forget write plus an immediate callback never reaches the database.
+        try {
+            this.setStateChanged('info.connection', false, true, () => callback());
+        } catch {
+            callback();
+        }
     }
 }
 


### PR DESCRIPTION
## What users see

Every time the adapter is stopped or restarted while the TV is connected, the log shows

```
warn: lgtv.1 (…) setTimeout called, but adapter is shutting down
```

Instances whose TV is off do not show it.

## Why

`onUnload` calls `disconnect()` and returns the callback right away. lgtv2 closes the socket and emits `close` shortly afterwards, when the adapter is already shutting down. The `close` handler runs `checkConnection()`, which schedules the usual 10 s re-check with `this.setTimeout`, and adapter-core refuses that with the warning. Nothing is lost — the timer is simply dropped — it is only noise on every stop.

## Change

An `unloading` flag is set at the top of `onUnload`; `checkConnection()` returns early while it is set. Everything else stays as it is.

## Test plan

- [x] `npm run build`, `npm run check`, `npm run lint`, `npm test` — green
- [x] Deployed on an installation with two instances (one TV connected, one powered off), stopped and started both: the warning is gone, both come back and reconnect

## Note

Independent of #476; both add a line under `### **WORK IN PROGRESS**` in the README changelog, so whichever merges second needs that one-line conflict resolved.