### PR TITLE
Keep the adapter's files inside the ioBroker data directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Details that bite:
 - `unsignedPairing()` adds `CONTROL_INPUT_TEXT` and `CONTROL_MOUSE_AND_KEYBOARD` to the permissions, because those two only exist inside the signed block. Without them the client key the TV hands out is rejected by `getPointerInputSocket` with "401 insufficient permissions" and every `remote.*` button, move, scroll and click is dead.
 - `request(uri, cb)` works: the callback overload is listed before the promise one, because a function also satisfies `Record<string, any>` and would otherwise be taken for a payload. `request(uri, {}, cb)` is equally fine and is what `main.ts` uses.
 - `disconnect()` returns a promise that only ever resolves.
+- **`keyFile` has to be passed in.** Without it lgtv2 falls back to `defaultKeyDir()` — `$LGTV2_KEY_DIR`, `%APPDATA%` or `$HOME/.lgtv2` — and derives `<keyFile>.mac` and `<keyFile>.cert` from there, which would put adapter files in the home directory of the ioBroker user. `saveKey` alone only covers the client key itself.
 
 ### Command helpers
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ Install this adapter using ioBroker repositories.
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (krobipd) The adapter no longer creates files in the home directory of the ioBroker user; the client key, the MAC cache and the certificate file all stay in the adapter's data directory
+
 ### 3.0.3 (2026-09-05)
 - (GermanBluefox) The WebOS 26 pairing fallback now also asks for the pointer permissions, so the remote buttons, pointer moves, scrolling and clicks work after a fresh pairing
 - (GermanBluefox) Older TVs get the signed pairing manifest again; the unsigned manifest is only used after the TV rejected the signed one (ported from lgtv2 2.0.1)

--- a/src/main.ts
+++ b/src/main.ts
@@ -587,6 +587,14 @@ class LgTv extends utils.Adapter {
             timeout,
             reconnect,
             clientKey: this.clientKey,
+            // Without keyFile lgtv2 derives its file paths from $LGTV2_KEY_DIR / %APPDATA% / $HOME,
+            // so `<keyFile>.mac` (and `.cert`, once verifyCert is used) would end up in the home
+            // directory of the ioBroker user instead of the adapter's data directory. saveKey
+            // already writes the client key here; this makes the rest follow.
+            keyFile: this.keyFile,
+            // The MACs lgtv2 learns from the TV are never read: wakeTv() uses states.mac and the
+            // configured MAC. Learning them only wrote a file nobody looks at.
+            learnMac: false,
             saveKey: (key, keyCb) => {
                 writeFile(this.keyFile, key, keyCb);
             },


### PR DESCRIPTION
`connect()` builds the `LGTV` instance without `keyFile`, so lgtv2 falls back to `defaultKeyDir()` — `$LGTV2_KEY_DIR`, `%APPDATA%` or `$HOME/.lgtv2` — and derives `macFile` and `certFile` from there.

`learnMac` defaults to `true`, so after the first successful pairing the adapter writes `<HOME>/.lgtv2/macfile-<ip>` on every installation: a file outside the adapter's data directory, which no ioBroker backup covers and which ends up in `os.tmpdir()` in a container without `HOME`. On the very first start, before a key file exists, the same fallback also makes lgtv2 **read** `<HOME>/.lgtv2/keyfile-<ip>`, so a stray key left by another tool would be picked up.

`saveKey` only ever covered the client key itself.

## Change

* pass `keyFile`, so `.mac` and `.cert` land next to the key file in the adapter's data directory
* `learnMac: false` — nothing in the adapter consumes what lgtv2 learns: `wakeTv()` uses `states.mac` and the configured MAC, and the `mac` event and the `macs`/`mac` getters are unused. Dropping the option again is all it takes if the adapter ever wants them — the file then lands in the data directory with the key file

## Verified

Path resolution measured against `build/lgtv2/index.js` with the exact options `connect()` passes, for `clientKey` `undefined` (first start) and `''` (every later start):

| | before | after |
|---|---|---|
| `keyFile` | `<HOME>/.lgtv2/keyfile-<ip>` | `<data dir>/lgtv_0/lgtvkeyfile` |
| `macFile` | `<HOME>/.lgtv2/macfile-<ip>` | `<data dir>/lgtv_0/lgtvkeyfile.mac` |
| `certFile` | `<HOME>/.lgtv2/certfile-<ip>` | `<data dir>/lgtv_0/lgtvkeyfile.cert` |

Then run against a real TV (webOS 6.5) on a local dev-server: after connecting and pairing, `$HOME/.lgtv2` does not exist and the instance data directory holds only `lgtvkeyfile` — no `.mac` file is created any more.

`npm run build`, `check`, `lint`, `test:js` (34) and `test:package` (70) all pass.

