### PR TITLE
Accept pointer movements with a zero on one axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ Install this adapter using ioBroker repositories.
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (krobipd) `states.scroll` and `states.drag` no longer ignore a movement whose horizontal or vertical part is zero, so plain vertical scrolling (`0,5`) works
+
 ### 3.0.3 (2026-09-05)
 - (GermanBluefox) The WebOS 26 pairing fallback now also asks for the pointer permissions, so the remote buttons, pointer moves, scrolling and clicks work after a fresh pairing
 - (GermanBluefox) Older TVs get the signed pairing manifest again; the unsigned manifest is only used after the TV rejected the signed one (ported from lgtv2 2.0.1)

--- a/src/main.ts
+++ b/src/main.ts
@@ -431,7 +431,8 @@ class LgTv extends utils.Adapter {
 
             case 'states.drag':
                 // The event type is 'move' for both moves and drags.
-                if (dx && dy) {
+                // A zero on one axis is a valid movement, so this must not be a truthiness check.
+                if (dx !== undefined && dy !== undefined && Number.isFinite(dx) && Number.isFinite(dy)) {
                     this.sendCommand('move', { dx, dy, drag: vals?.[2] === 'drag' ? 1 : 0 }, err => {
                         if (!err) {
                             void this.setState(id, state.val, true);
@@ -441,7 +442,8 @@ class LgTv extends utils.Adapter {
                 break;
 
             case 'states.scroll':
-                if (dx && dy) {
+                // Scrolling is almost always vertical only ("0,5"), so a zero dx has to pass.
+                if (dx !== undefined && dy !== undefined && Number.isFinite(dx) && Number.isFinite(dy)) {
                     this.sendCommand('scroll', { dx, dy }, err => {
                         if (!err) {
                             void this.setState(id, state.val, true);


### PR DESCRIPTION
`states.drag` and `states.scroll` gate the command behind `if (dx && dy)`. `parseInt('0')` is `0` and therefore falsy, so every movement along a single axis is dropped — without a log line.

That includes `"0,5"`: plain vertical scrolling, which is the most common case of all. Only diagonal movements get through today.

## Change

`Number.isFinite(dx) && Number.isFinite(dy)` instead of the truthiness check. This also covers the `NaN` case the old check happened to catch on the way.

## Verified

Against a real TV (webOS 6.5) on a local dev-server. Writing to `lgtv.0.states.scroll` and reading the state back:

| value | before | after |
|---|---|---|
| `"3,5"` (diagonal) | acknowledged | acknowledged |
| `"0,5"` (vertical only) | not acknowledged, nothing sent | acknowledged |
| `"5,0"` (horizontal only) | not acknowledged, nothing sent | acknowledged |

The acknowledgement is written inside the guarded block, so `ack=true` on the state is the proof that the command reached the pointer input socket.

`npm run build`, `check`, `lint`, `test:js` (34) and `test:package` (70) all pass.
