### PR TITLE
Keep the volume ramp to one target and out of NaN

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ Install this adapter using ioBroker repositories.
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (krobipd) Two volume changes in quick succession no longer fight over the TV, and an unreadable volume from the TV no longer disables the stepped volume ramp
+
 ### 3.0.3 (2026-09-05)
 - (GermanBluefox) The WebOS 26 pairing fallback now also asks for the pointer permissions, so the remote buttons, pointer moves, scrolling and clicks work after a fresh pairing
 - (GermanBluefox) Older TVs get the signed pairing manifest again; the unsigned manifest is only used after the TV rejected the signed one (ported from lgtv2 2.0.1)

--- a/src/main.ts
+++ b/src/main.ts
@@ -148,6 +148,8 @@ class LgTv extends utils.Adapter {
     private clientKey: string | undefined = undefined;
     private volume = 0;
     private oldVolume = 0;
+    /** handle of the stepped volume ramp started by setVolume(), if one is running */
+    private volumeRamp: ioBroker.Interval | undefined = undefined;
     private keyFile = 'lgtvkeyfile';
     private curApp = '';
     private renewTimeout: ioBroker.Timeout | undefined = undefined;
@@ -654,9 +656,10 @@ class LgTv extends utils.Adapter {
             }
             if (res.changed) {
                 if (res.changed.includes('volume') && res.volume != null) {
-                    this.volume = parseInt(String(res.volume));
-                    if (Number.isFinite(this.volume)) {
-                        void this.setState('states.volume', this.volume, true);
+                    const volume = parseInt(String(res.volume));
+                    if (Number.isFinite(volume)) {
+                        this.volume = volume;
+                        void this.setState('states.volume', volume, true);
                     }
                 }
                 if (res.changed.includes('muted') && res.muted != null) {
@@ -665,9 +668,10 @@ class LgTv extends utils.Adapter {
             } else if (res.volumeStatus) {
                 const status = res.volumeStatus;
                 if (status.volume != null) {
-                    this.volume = parseInt(String(status.volume));
-                    if (Number.isFinite(this.volume)) {
-                        void this.setState('states.volume', this.volume, true);
+                    const volume = parseInt(String(status.volume));
+                    if (Number.isFinite(volume)) {
+                        this.volume = volume;
+                        void this.setState('states.volume', volume, true);
                     }
                 }
                 if (status.muteStatus != null) {
@@ -1070,18 +1074,28 @@ class LgTv extends utils.Adapter {
     }
 
     private setVolume(val: number): void {
+        // A ramp still running belongs to an older target and would keep stepping towards it,
+        // so two quick writes to states.volume would fight over the TV every 500 ms.
+        this.stopVolumeRamp();
         if (val >= this.volume + 5) {
             let vol = this.oldVolume;
-            const interval = this.setInterval(() => {
+            this.volumeRamp = this.setInterval(() => {
                 vol = vol + 2;
                 if (vol >= val) {
                     vol = val;
-                    this.clearInterval(interval);
+                    this.stopVolumeRamp();
                 }
                 this.sendCommand('ssap://audio/setVolume', { volume: vol });
             }, 500);
         } else {
             this.sendCommand('ssap://audio/setVolume', { volume: val });
+        }
+    }
+
+    private stopVolumeRamp(): void {
+        if (this.volumeRamp) {
+            this.clearInterval(this.volumeRamp);
+            this.volumeRamp = undefined;
         }
     }
 
@@ -1126,6 +1140,7 @@ class LgTv extends utils.Adapter {
     private onUnload(callback: () => void): void {
         try {
             this.clearTimeout(this.renewTimeout);
+            this.stopVolumeRamp();
             if (this.healthInterval) {
                 this.clearInterval(this.healthInterval);
             }


### PR DESCRIPTION
Two defects around the volume, both in the same area:

**The stepped ramp never stops the previous one.** `setVolume()` starts a ramp for jumps of 5 or more, but does not clear a ramp that is already running. Two writes to `states.volume` in quick succession leave two intervals stepping towards different targets, each sending `setVolume` to the TV every 500 ms. The ramp was not stopped on unload either.

**The volume snapshot is assigned before it is validated.** `this.volume = parseInt(...)` followed by a `Number.isFinite` check on the field. A volume the TV reports unparseably leaves `NaN` in the field for good — and `val >= this.volume + 5` is false against `NaN`, so the ramp silently never runs again.

## Change

* new field `volumeRamp` plus `stopVolumeRamp()`, so the ramp has a handle that outlives the closure
* `setVolume()` calls `stopVolumeRamp()` first — on both paths, so switching from a ramp to a direct set also cancels the old one
* `onUnload` clears the ramp as well
* the parsed volume is checked first in both `audio/getVolume` branches; only a finite value is kept

## Verified

`npm run build`, `check`, `lint`, `test:js` (34) and `test:package` (70) all pass.

Not exercised against a TV: reproducing it means driving the volume of a set that is in use.
