### PR TITLE
Declare the moment dependency of the devices dev harness

### DIFF
--- a/src-devices/package-lock.json
+++ b/src-devices/package-lock.json
@@ -22,6 +22,7 @@
                 "@types/react": "^19.2.18",
                 "@types/react-dom": "^19.2.5",
                 "@vitejs/plugin-react": "^6.1.1",
+                "moment": "^2.30.1",
                 "react": "^19.2.8",
                 "react-dom": "^19.2.8",
                 "vite": "^8.2.2",

--- a/src-devices/package.json
+++ b/src-devices/package.json
@@ -21,6 +21,7 @@
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.5",
         "@vitejs/plugin-react": "^6.1.1",
+        "moment": "^2.30.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "vite": "^8.2.2",


### PR DESCRIPTION
`src-devices/src/dev-dm-widgets.ts` imports `moment` to re-provide the host-bridged export of `@iobroker/dm-widgets` (`build/index.js`: `export const moment = _shared.moment`). No `package.json` declares it.

It resolves today only because two unrelated paths happen to hoist it into `src-devices/node_modules`:

* `@iobroker/gui-components` → `@iobroker/js-controller-common-db` → `winston-daily-rotate-file` → `file-stream-rotator` → `moment`
* `@iobroker/json-config` → `@mui/x-date-pickers` → `moment`

Either can drop `moment` in any minor release — `@mui/x-date-pickers` works with date-fns and luxon just as well — and the harness would then fail on an import it never declared.

Reported by the repository checker as W5042.

## Note on the other four W5042 hits for this file

`react`, `@mui/material`, `@mui/icons-material` and `@iobroker/gui-components` are correct as they are and should **not** be added to the root `package.json`: the shipped widget receives them from the admin host through Module Federation (they are listed under `shared` in `admin/dm-widgets/mf-manifest.json`). They belong in `src-devices` as devDependencies for the build, which is where they already are.

## Verified

`npm install` in `src-devices/` with and without the entry: 339 packages either way, so this changes nothing about what gets installed today — it only stops the harness from depending on someone else's dependency tree. `npm run check-devices` passes.
