### PR TITLE
Let dependabot watch the devices widget

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,20 @@ updates:
         update-types:
           - 'version-update:semver-major'
 
+  # The devices widget under src-devices/ has its own package.json, and its build output in
+  # admin/dm-widgets/ is committed and shipped. Without this entry no security update ever
+  # reaches the code that actually goes out with the adapter.
+  - package-ecosystem: 'npm'
+    directory: '/src-devices'
+    schedule:
+      interval: 'cron'
+      timezone: 'Europe/Berlin'
+      cronjob: '23 3 24 * *'
+    open-pull-requests-limit: 15
+    versioning-strategy: 'increase'
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
The npm entry in `.github/dependabot.yml` only covers the repository root, so `src-devices/package.json` is never checked.

That directory pulls React 19, Vite 8 and MUI 9 — and its build output in `admin/dm-widgets/` is committed and shipped with the adapter. The one tree whose dependencies actually reach users was the one dependabot did not look at.

Reported by the repository checker as W8905.

## Change

A second npm entry for `/src-devices`, with the same schedule, cooldown and PR limit as the root entry.
